### PR TITLE
Improve routing algorithm

### DIFF
--- a/benchmarks/py2qan_larger_benchmarks.ipynb
+++ b/benchmarks/py2qan_larger_benchmarks.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d6fa6a3d-b4e4-41d5-bff7-ea16831b80dd",
+   "metadata": {},
+   "source": [
+    "# Testing 2QAN on different coupling graphs and larger benchmark circuits\n",
+    "\n",
+    "In this notebook, we benchmark the performance of py2qan across a range of circuit types (100 qubits each unless otherwise marked):\n",
+    "\n",
+    "- Quantum Approximate Optimization Algorithm (QAOA)\n",
+    "- Quantum volume (QV) calculation\n",
+    "- Quantum Fourier transform (QFT)\n",
+    "- Square Heisenberg model Trotterized Hamiltonian simulation\n",
+    "- Quantum computational neural network (QCNN)\n",
+    "- PREPARE & SELECT on a 25 qubit GHZ state\n",
+    "\n",
+    "### Circuit definitions\n",
+    "For the QAOA, QFT, Square Heisenberg, and QV circuits, we copy the corresponding OpenQASM 2 code from qiskit's benchpress library. For the QCNN and Prepare & Select circuits, we generate QASM 2 code using our own implementations in qiskit and cirq, decomposed into the restricted basis set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c324ce64-ee3f-4237-8132-a227576f8363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "folder = \"./qasm_circuits/qasm2/\"\n",
+    "\n",
+    "qasm_files = [folder + file for file in [\n",
+    "    \"benchpress/qaoa_barabasi_albert_N100_3reps_basis_rz_rx_ry_cx.qasm\",\n",
+    "    \"benchpress/qv_N100_12345_basis_rz_rx_ry_cx.qasm\",\n",
+    "    \"benchpress/qft_N100_basis_rz_rx_ry_cx.qasm\",\n",
+    "    \"benchpress/square_heisenberg_N100_basis_rz_rx_ry_cx.qasm\",\n",
+    "    \"ucc/prep_select_N25_ghz_basis_rz_rx_ry_h_cx.qasm\",\n",
+    "    \"ucc/qcnn_N100_7layers_basis_rz_rx_ry_h_cx.qasm\"\n",
+    "    ]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5ff4c7fd-c4ed-4094-b7fd-b35a2a6d4ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qasm_strings = []\n",
+    "for filename in qasm_files:\n",
+    "    with open(filename, \"r\") as file:\n",
+    "        qasm_strings.append(file.read())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a63a039d-e497-4a81-aa08-d444089aa3a4",
+   "metadata": {},
+   "source": [
+    "We also generate different coupling graphs (in the form of lists of edges) to test circuit mapping and routing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "00274f69-fe3b-44e4-8062-489dc53a546e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.scripts.generate_layouts import generate_tilted_square_coupling_list, generate_heavy_hex_coupling_list\n",
+    "coupling_lists = {\"cl_sycamore\": generate_tilted_square_coupling_list(15, 12), \"cl_hhex\": generate_heavy_hex_coupling_list(7)} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c5982704-dbac-4408-a30c-c0a1cf261c3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import time\n",
+    "# Import 2QAN compiler passes\n",
+    "from py2qan import BenchArch\n",
+    "from py2qan import HeuristicMapper\n",
+    "from py2qan import QuRouter\n",
+    "# Import qiskit \n",
+    "import qiskit\n",
+    "from qiskit.transpiler import CouplingMap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9196657-602f-4572-97d6-d3168a8c9156",
+   "metadata": {},
+   "source": [
+    "Copied `qs_compiler` function from qiskit comparison notebook, removed the code comparing with qiskit for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "156a55af-5099-46f6-9010-c596cb7c604f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def qs_compiler(qasm, coupling_map, layers=1, trials=1):\n",
+    "    qs_circ = None\n",
+    "    qs_swap = (0, 0) # the number of swaps in the format (#swaps,#swaps merged with circuit gate)\n",
+    "    qs_g2 = 0 # the number of two-qubit gates without decomposition\n",
+    "    # Perform qubit mapping, routing, and scheduling only, without gate decomposition\n",
+    "    for trial in range(trials):\n",
+    "        # Both QAP and Qiskit mappers output inital qubit maps randomly, \n",
+    "        # one can run the mapper several times to achieve better compilation results\n",
+    "        # Initial qubit mapping \n",
+    "        hmapper = HeuristicMapper(qasm, coupling_map=coupling_map)\n",
+    "        init_map = hmapper.run_qiskit(max_iterations=5)\n",
+    "        \n",
+    "        # init_map = {circuit qubit index:device qubit index}\n",
+    "        print('The initial qubit map is \\n', init_map)\n",
+    "        start = time.time()\n",
+    "        # Routing and scheduling, takes init_map as input\n",
+    "        router = QuRouter(qasm, init_map=init_map, coupling_map=coupling_map)\n",
+    "        # For quantum simulation circuits, we assume each layer has the same time steps\n",
+    "        qs_circ, swaps = router.run(layers=layers, msmt='True')\n",
+    "        # qs_circ0 is the routed circuit without gate decomposition\n",
+    "        # swaps1 is a tuple=(#swaps,#swaps merged with circuit gate)\n",
+    "        end = time.time()\n",
+    "        print(\"Router run time: \", end - start)\n",
+    "        return qs_circ, swaps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cfedbcb8-94d6-4185-aa69-d4ed6edef5b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The initial qubit map is \n",
+      " {0: 12, 1: 43, 2: 56, 3: 84, 4: 90, 5: 100, 6: 74, 7: 89, 8: 81, 9: 92, 10: 48, 11: 91, 12: 32, 13: 31, 14: 28, 15: 64, 16: 63, 17: 4, 18: 0, 19: 1, 20: 37, 21: 35, 22: 20, 23: 21, 24: 5, 25: 7, 26: 19, 27: 98, 28: 2, 29: 71, 30: 16, 31: 6, 32: 65, 33: 47, 34: 66, 35: 97, 36: 26, 37: 44, 38: 55, 39: 80, 40: 8, 41: 49, 42: 102, 43: 61, 44: 99, 45: 36, 46: 53, 47: 95, 48: 3, 49: 13, 50: 23, 51: 72, 52: 85, 53: 54, 54: 45, 55: 29, 56: 70, 57: 96, 58: 86, 59: 50, 60: 82, 61: 76, 62: 22, 63: 46, 64: 25, 65: 51, 66: 68, 67: 11, 68: 27, 69: 79, 70: 83, 71: 18, 72: 78, 73: 40, 74: 75, 75: 62, 76: 42, 77: 10, 78: 58, 79: 94, 80: 24, 81: 38, 82: 60, 83: 57, 84: 101, 85: 41, 86: 52, 87: 67, 88: 9, 89: 14, 90: 69, 91: 59, 92: 103, 93: 73, 94: 87, 95: 77, 96: 15, 97: 93, 98: 17, 99: 88, 100: 30, 101: 33, 102: 34, 103: 39}\n",
+      "Router run time:  5.59675407409668\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(<qiskit.circuit.quantumcircuit.QuantumCircuit at 0x11db32d50>, (349, 47))"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qs_compiler(qasm_strings[0], CouplingMap(coupling_lists[\"cl_sycamore\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f05bb91-35a8-4107-9acf-2b69cedf4263",
+   "metadata": {},
+   "source": [
+    "Router seems to get stuck for these circuits- had to stop after ~5 min without any circuits routed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fadd931b-6a78-4396-ba23-25c72690c01d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The initial qubit map is \n",
+      " {0: 12, 1: 43, 2: 53, 3: 56, 4: 4, 5: 36, 6: 100, 7: 15, 8: 26, 9: 96, 10: 90, 11: 69, 12: 60, 13: 77, 14: 98, 15: 91, 16: 61, 17: 31, 18: 42, 19: 33, 20: 84, 21: 44, 22: 46, 23: 8, 24: 10, 25: 28, 26: 86, 27: 7, 28: 67, 29: 64, 30: 55, 31: 65, 32: 39, 33: 83, 34: 6, 35: 17, 36: 48, 37: 9, 38: 45, 39: 75, 40: 49, 41: 88, 42: 29, 43: 62, 44: 94, 45: 51, 46: 0, 47: 47, 48: 72, 49: 40, 50: 19, 51: 99, 52: 71, 53: 59, 54: 80, 55: 95, 56: 76, 57: 25, 58: 5, 59: 21, 60: 2, 61: 54, 62: 70, 63: 58, 64: 63, 65: 14, 66: 3, 67: 41, 68: 102, 69: 81, 70: 73, 71: 16, 72: 23, 73: 18, 74: 24, 75: 103, 76: 85, 77: 93, 78: 37, 79: 22, 80: 97, 81: 13, 82: 30, 83: 35, 84: 66, 85: 27, 86: 11, 87: 32, 88: 57, 89: 87, 90: 79, 91: 68, 92: 34, 93: 78, 94: 20, 95: 74, 96: 92, 97: 1, 98: 52, 99: 89, 100: 38, 101: 101, 102: 50, 103: 82}\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[10], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m qs \u001b[38;5;129;01min\u001b[39;00m qasm_strings[\u001b[38;5;241m1\u001b[39m:]:\n\u001b[0;32m----> 2\u001b[0m     \u001b[43mqs_compiler\u001b[49m\u001b[43m(\u001b[49m\u001b[43mqs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mCouplingMap\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcoupling_lists\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcl_sycamore\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[4], line 19\u001b[0m, in \u001b[0;36mqs_compiler\u001b[0;34m(qasm, coupling_map, layers, trials)\u001b[0m\n\u001b[1;32m     17\u001b[0m router \u001b[38;5;241m=\u001b[39m QuRouter(qasm, init_map\u001b[38;5;241m=\u001b[39minit_map, coupling_map\u001b[38;5;241m=\u001b[39mcoupling_map)\n\u001b[1;32m     18\u001b[0m \u001b[38;5;66;03m# For quantum simulation circuits, we assume each layer has the same time steps\u001b[39;00m\n\u001b[0;32m---> 19\u001b[0m qs_circ, swaps \u001b[38;5;241m=\u001b[39m \u001b[43mrouter\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlayers\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlayers\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmsmt\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mTrue\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;66;03m# qs_circ0 is the routed circuit without gate decomposition\u001b[39;00m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;66;03m# swaps1 is a tuple=(#swaps,#swaps merged with circuit gate)\u001b[39;00m\n\u001b[1;32m     22\u001b[0m end \u001b[38;5;241m=\u001b[39m time\u001b[38;5;241m.\u001b[39mtime()\n",
+      "File \u001b[0;32m~/Documents/GitHub/UCC-2QAN/py2qan/qrouter_depth.py:564\u001b[0m, in \u001b[0;36mQuRouter.run\u001b[0;34m(self, layers, msmt)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mrun\u001b[39m(\u001b[38;5;28mself\u001b[39m, layers\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, msmt\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFalse\u001b[39m\u001b[38;5;124m'\u001b[39m):\n\u001b[1;32m    563\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrouter()\n\u001b[0;32m--> 564\u001b[0m     ordered_all_instrs, dressed_instrs, ordered_all_instrs_phy \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mscheduler\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    565\u001b[0m     new_circ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconstruct_circ(ordered_all_instrs, dressed_instrs, \n\u001b[1;32m    566\u001b[0m                                     ordered_all_instrs_phy, layers, msmt)\n\u001b[1;32m    568\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m new_circ, (layers\u001b[38;5;241m*\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mswap_count, layers\u001b[38;5;241m*\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdswap_count)\n",
+      "File \u001b[0;32m~/Documents/GitHub/UCC-2QAN/py2qan/qrouter_depth.py:377\u001b[0m, in \u001b[0;36mQuRouter.scheduler\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    373\u001b[0m         unscheduled \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmap_moves[j\u001b[38;5;241m+\u001b[39m\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    374\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m move \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mreversed\u001b[39m(moves):\n\u001b[1;32m    375\u001b[0m     \u001b[38;5;66;03m# Movement can be scheduled only if \u001b[39;00m\n\u001b[1;32m    376\u001b[0m     \u001b[38;5;66;03m# the circuit gates that depend on it have been scheduled\u001b[39;00m\n\u001b[0;32m--> 377\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mqbt_overlap\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmove\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munscheduled\u001b[49m\u001b[43m)\u001b[49m:\n\u001b[1;32m    378\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmap_moves[n], cycles[dp], scheduled \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mschedule_cycle(move, cycles[dp], \n\u001b[1;32m    379\u001b[0m                                                     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmap_moves[n], cycle_maps[dp])\n\u001b[1;32m    380\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m scheduled:\n",
+      "File \u001b[0;32m~/Documents/GitHub/UCC-2QAN/py2qan/qrouter_depth.py:113\u001b[0m, in \u001b[0;36mQuRouter.qbt_overlap\u001b[0;34m(self, new_move, old_moves)\u001b[0m\n\u001b[1;32m    111\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m old_moves:\n\u001b[1;32m    112\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m mov \u001b[38;5;129;01min\u001b[39;00m old_moves:\n\u001b[0;32m--> 113\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28;43mset\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mmov\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;241m&\u001b[39m \u001b[38;5;28mset\u001b[39m(new_move):\n\u001b[1;32m    114\u001b[0m             overlap \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m    115\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m overlap\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "for qs in qasm_strings[1:]:\n",
+    "    qs_compiler(qs, CouplingMap(coupling_lists[\"cl_sycamore\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd49d858-d925-4864-923e-d2f19ad0985a",
+   "metadata": {},
+   "source": [
+    "Router seems to get stuck for this coupling map- had to stop after ~5 min without the circuit being routed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "51b1760b-0c35-452d-8cd4-41e5e028022b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The initial qubit map is \n",
+      " {0: 0, 1: 1, 2: 2, 3: 6, 4: 42, 5: 43, 6: 47, 7: 48, 8: 49, 9: 72, 10: 73, 11: 75, 12: 109, 13: 110, 14: 114, 15: 88, 16: 26, 17: 22, 18: 99, 19: 61, 20: 15, 21: 87, 22: 21, 23: 57, 24: 38, 25: 39, 26: 70, 27: 91, 28: 106, 29: 67, 30: 85, 31: 71, 32: 29, 33: 84, 34: 54, 35: 9, 36: 50, 37: 107, 38: 28, 39: 80, 40: 14, 41: 8, 42: 98, 43: 19, 44: 90, 45: 27, 46: 12, 47: 16, 48: 36, 49: 20, 50: 60, 51: 105, 52: 96, 53: 35, 54: 112, 55: 51, 56: 52, 57: 17, 58: 45, 59: 40, 60: 53, 61: 56, 62: 104, 63: 32, 64: 86, 65: 11, 66: 79, 67: 13, 68: 10, 69: 41, 70: 64, 71: 103, 72: 77, 73: 108, 74: 4, 75: 37, 76: 83, 77: 65, 78: 66, 79: 34, 80: 76, 81: 69, 82: 100, 83: 7, 84: 18, 85: 46, 86: 44, 87: 113, 88: 97, 89: 82, 90: 78, 91: 102, 92: 5, 93: 33, 94: 74, 95: 55, 96: 3, 97: 81, 98: 111, 99: 89, 100: 92, 101: 23, 102: 93, 103: 24, 104: 94, 105: 25, 106: 95, 107: 30, 108: 31, 109: 101, 110: 58, 111: 59, 112: 62, 113: 63, 114: 68}\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mqs_compiler\u001b[49m\u001b[43m(\u001b[49m\u001b[43mqasm_strings\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mCouplingMap\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcoupling_lists\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcl_hhex\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[4], line 19\u001b[0m, in \u001b[0;36mqs_compiler\u001b[0;34m(qasm, coupling_map, layers, trials)\u001b[0m\n\u001b[1;32m     17\u001b[0m router \u001b[38;5;241m=\u001b[39m QuRouter(qasm, init_map\u001b[38;5;241m=\u001b[39minit_map, coupling_map\u001b[38;5;241m=\u001b[39mcoupling_map)\n\u001b[1;32m     18\u001b[0m \u001b[38;5;66;03m# For quantum simulation circuits, we assume each layer has the same time steps\u001b[39;00m\n\u001b[0;32m---> 19\u001b[0m qs_circ, swaps \u001b[38;5;241m=\u001b[39m \u001b[43mrouter\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlayers\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlayers\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmsmt\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mTrue\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;66;03m# qs_circ0 is the routed circuit without gate decomposition\u001b[39;00m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;66;03m# swaps1 is a tuple=(#swaps,#swaps merged with circuit gate)\u001b[39;00m\n\u001b[1;32m     22\u001b[0m end \u001b[38;5;241m=\u001b[39m time\u001b[38;5;241m.\u001b[39mtime()\n",
+      "File \u001b[0;32m~/Documents/GitHub/UCC-2QAN/py2qan/qrouter_depth.py:564\u001b[0m, in \u001b[0;36mQuRouter.run\u001b[0;34m(self, layers, msmt)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mrun\u001b[39m(\u001b[38;5;28mself\u001b[39m, layers\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, msmt\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFalse\u001b[39m\u001b[38;5;124m'\u001b[39m):\n\u001b[1;32m    563\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrouter()\n\u001b[0;32m--> 564\u001b[0m     ordered_all_instrs, dressed_instrs, ordered_all_instrs_phy \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mscheduler\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    565\u001b[0m     new_circ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconstruct_circ(ordered_all_instrs, dressed_instrs, \n\u001b[1;32m    566\u001b[0m                                     ordered_all_instrs_phy, layers, msmt)\n\u001b[1;32m    568\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m new_circ, (layers\u001b[38;5;241m*\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mswap_count, layers\u001b[38;5;241m*\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdswap_count)\n",
+      "File \u001b[0;32m~/Documents/GitHub/UCC-2QAN/py2qan/qrouter_depth.py:373\u001b[0m, in \u001b[0;36mQuRouter.scheduler\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    371\u001b[0m     unscheduled \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmap_instrs[j]\n\u001b[1;32m    372\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m j \u001b[38;5;241m<\u001b[39m n_maps\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m:\n\u001b[0;32m--> 373\u001b[0m         unscheduled \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmap_moves[j\u001b[38;5;241m+\u001b[39m\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    374\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m move \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mreversed\u001b[39m(moves):\n\u001b[1;32m    375\u001b[0m     \u001b[38;5;66;03m# Movement can be scheduled only if \u001b[39;00m\n\u001b[1;32m    376\u001b[0m     \u001b[38;5;66;03m# the circuit gates that depend on it have been scheduled\u001b[39;00m\n\u001b[1;32m    377\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mqbt_overlap(move, unscheduled):\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "qs_compiler(qasm_strings[0], CouplingMap(coupling_lists[\"cl_hhex\"]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py2qan-upgrade-test-venv",
+   "language": "python",
+   "name": "py2qan-upgrade-test"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ucc/transpiler_passes/bench_arch.py
+++ b/ucc/transpiler_passes/bench_arch.py
@@ -1,0 +1,118 @@
+import numpy as np
+import math
+import networkx as nx
+from qiskit import QuantumCircuit
+from qiskit.circuit import Barrier, Measure
+from qiskit.circuit.library.standard_gates import HGate
+
+class BenchArch(object):
+    """Base class for generating device coupling graph, circuit dag graph"""
+    def __init__(self, qasm, lattice_xy=None, coupling_map=None):
+        """
+        Args:
+            qasm: circuit in OpenQASM format
+            lattice_xy: (x,y) if coupling_map is not given and the topology is grid
+            coupling_map: connectivity between qubits such as 
+            [(0,1), (1,2), (2,3), (3,4), (4,5), (5,6), (6,7), (0,7), (0,8), (1,9), (0,10)]
+        """
+        # Transform OpenQASM to qiskit circuit
+        self.benchmark = QuantumCircuit.from_qasm_str(qasm)
+        self.b_qbts = len(self.benchmark.qubits)
+        # Generate the topology graph (2d grid) and the distance matrix
+        if coupling_map:
+            self.coupling_map = coupling_map
+        else:
+            self.lattice_x, self.lattice_y = lattice_xy
+            self.coupling_map = self.grid_coupling()
+
+        # n_qbits is the number of qubits in the given topology
+        self.topology, self.distmat, self.n_qbits = self.topology_graph()
+        self.G_circ, self.pairs, self.instrs, self.q1_instrs = self.circuit_graph()
+        adjmat_csr = nx.adjacency_matrix(self.G_circ)
+        self.adjmat = adjmat_csr.todense() 
+
+    def zz_tuple(self, qbits):
+        """
+        Representation for two-qubit gate
+        """
+        if isinstance(qbits[0], int):
+            physical_q_0 = qbits[0]
+            physical_q_1 = qbits[1]
+        else:
+            physical_q_0 = qbits[0]._index
+            physical_q_1 = qbits[1]._index
+        r_0 = min(physical_q_0, physical_q_1)
+        r_1 = max(physical_q_0, physical_q_1)
+        return (r_0, r_1)
+
+    def circuit_graph(self):
+        # Generate the interaction graph of the input circuit and the interaction matrix
+        qpairs = []
+        all_qs = []
+        instrs2q = {}
+        instrs1q = {0: [], 1:[]}
+        for instr, qbits, cbits in self.benchmark.data:
+            if len(qbits) == 2:
+                qpairs.append((qbits[0]._index, qbits[1]._index))
+                instrs2q[self.zz_tuple(qbits)] = instr
+            elif len(qbits) == 1:
+                if isinstance(instr, Barrier):
+                    continue
+                elif isinstance(instr, Measure):
+                    continue
+                elif isinstance(instr, HGate):
+                    instrs1q[0].append((instr, qbits[0]._index))
+                else:
+                    instrs1q[1].append((instr, qbits[0]._index))
+            for q in qbits:
+                if q not in all_qs:
+                    all_qs.append(q)
+        G_circ = nx.Graph()
+        G_circ.add_nodes_from(np.arange(self.n_qbits))
+        G_circ.add_edges_from(qpairs)
+        return G_circ, qpairs, instrs2q, instrs1q
+
+    def instruction_graph(self, qpairs):
+        qbits = []
+        for qpair in qpairs:
+            for q in qpair:
+                if q not in qbits:
+                    qbits.append(q)
+
+        G = nx.Graph()
+        G.add_nodes_from(qbits)
+        G.add_edges_from(qpairs)
+        return G
+
+    def grid_coupling(self):
+        # Generate the 2d grid coupling map
+        pnodes = [(x, y) for y in range(0, self.lattice_y) for x in range(0, self.lattice_x)]
+        locs_pqbits = {}
+        for node in pnodes:
+            locs_pqbits[node] = node[1]*self.lattice_x+node[0]
+        topology_edges = []
+        for i in range(len(pnodes)):
+            node = pnodes[i]
+            for j in range(i+1,len(pnodes)):
+                if abs(pnodes[j][0]-node[0]) + abs(pnodes[j][1]-node[1]) == 1:
+                    topology_edges.append((locs_pqbits[node], locs_pqbits[pnodes[j]]))
+        return topology_edges
+
+    def topology_graph(self):
+        # Generate the topology graph and the distance matrix
+        all_qbts = []
+        for qpair in self.coupling_map:
+            for q in qpair:
+                if q not in all_qbts:
+                    all_qbts.append(q)
+        n_qbits = len(all_qbts)
+        topology = nx.Graph()
+        topology.add_nodes_from(np.arange(n_qbits))
+        topology.add_edges_from(self.coupling_map)
+
+        distmat = np.zeros((n_qbits, n_qbits))
+        for i in range(n_qbits-1):
+            for j in range(i+1, n_qbits):
+                distmat[i,j] = nx.shortest_path_length(topology, source=i, target=j)
+                distmat[j,i] = distmat[i,j]
+        return topology, distmat, n_qbits

--- a/ucc/transpiler_passes/py2qan_plugin.py
+++ b/ucc/transpiler_passes/py2qan_plugin.py
@@ -1,0 +1,20 @@
+from qiskit import QuantumCircuit
+from qiskit.transpiler import TransformationPass
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.qasm2 import dumps
+
+from py2qan import HeuristicMapper, QuRouter
+
+class Py2QAN_Mapping_Routing(TransformationPass):
+
+    def __init__(self, coupling_map):
+        super().__init__()
+        self.coupling_map = coupling_map
+
+    def run(self, dag):
+        qasm_rep = dumps(dag_to_circuit(dag))
+        hmapper = HeuristicMapper(qasm_rep, coupling_map=self.coupling_map)
+        init_map = hmapper.run_qiskit(max_iterations=5)
+        router = QuRouter(qasm_rep, init_map=init_map, coupling_map=self.coupling_map)
+        routed_circ, _ = router.run(layers=1, msmt=False)
+        return circuit_to_dag(QuantumCircuit.from_qasm_str(routed_circ))

--- a/ucc/transpiler_passes/py2qan_plugin.py
+++ b/ucc/transpiler_passes/py2qan_plugin.py
@@ -1,21 +1,63 @@
-from qiskit import QuantumCircuit
-from qiskit.transpiler import TransformationPass
+import os
+
+from qiskit import QuantumCircuit, user_config
+from qiskit.transpiler import TransformationPass, PassManager
+from qiskit.transpiler.passes import SabreLayout
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.qasm2 import dumps
+from qiskit.utils.parallel import CPU_COUNT
 
 from py2qan import HeuristicMapper, QuRouter
 
+
+CONFIG = user_config.get_config()
+
+
 class Py2QAN_Routing(TransformationPass):
 
-    def __init__(self, init_map, coupling_map):
+    def __init__(self, coupling_map):
         super().__init__()
-        self.init_map = init_map
         self.coupling_map = coupling_map
+        self.inner_pm = PassManager()
+
+    def fill_partial_mapping(self, partial_map, coupling_map):
+        # Fill the qubit map when #qubits in the circuit is fewer than #qubits in the given topology
+        final_map = partial_map.copy()
+        n_qbts = len(partial_map)
+        device_qubits = []
+        for edge in coupling_map:
+            for q in edge:
+                if q not in device_qubits:
+                    device_qubits.append(q)
+        unused_dqs = [q for q in device_qubits if q not in partial_map.values()]
+        for i in range(len(unused_dqs)):
+            final_map[n_qbts+i]=unused_dqs[i]
+        return final_map
 
     def run(self, dag):
-        qasm_rep = dumps(dag_to_circuit(dag))
+        circ = dag_to_circuit(dag)
         # hmapper = HeuristicMapper(qasm_rep, coupling_map=self.coupling_map)
         # init_map = hmapper.run_qiskit(max_iterations=5)
-        router = QuRouter(qasm_rep, init_map=self.init_map, coupling_map=self.coupling_map)
+        self.inner_pm.append(
+               SabreLayout(
+                  self.coupling_map,
+                  max_iterations=4,
+                  swap_trials=_get_trial_count(20),
+                  layout_trials=_get_trial_count(20),
+               )
+            )
+        self.inner_pm.run(circ)
+        vpmap = self.inner_pm.property_set["layout"].get_virtual_bits()
+        init_map0 = {}
+        for k,v in vpmap.items():
+            init_map0[k._index]=v
+        init_map = self.fill_partial_mapping(init_map0, self.coupling_map)
+
+        router = QuRouter(dumps(circ), init_map=init_map, coupling_map=self.coupling_map)
         routed_circ, _ = router.run(layers=1, msmt=False)
         return circuit_to_dag(QuantumCircuit.from_qasm_str(routed_circ))
+
+def _get_trial_count(default_trials=5):
+    if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+        return max(CPU_COUNT, default_trials)
+    return default_trials

--- a/ucc/transpiler_passes/py2qan_plugin.py
+++ b/ucc/transpiler_passes/py2qan_plugin.py
@@ -5,16 +5,17 @@ from qiskit.qasm2 import dumps
 
 from py2qan import HeuristicMapper, QuRouter
 
-class Py2QAN_Mapping_Routing(TransformationPass):
+class Py2QAN_Routing(TransformationPass):
 
-    def __init__(self, coupling_map):
+    def __init__(self, init_map, coupling_map):
         super().__init__()
+        self.init_map = init_map
         self.coupling_map = coupling_map
 
     def run(self, dag):
         qasm_rep = dumps(dag_to_circuit(dag))
-        hmapper = HeuristicMapper(qasm_rep, coupling_map=self.coupling_map)
-        init_map = hmapper.run_qiskit(max_iterations=5)
-        router = QuRouter(qasm_rep, init_map=init_map, coupling_map=self.coupling_map)
+        # hmapper = HeuristicMapper(qasm_rep, coupling_map=self.coupling_map)
+        # init_map = hmapper.run_qiskit(max_iterations=5)
+        router = QuRouter(qasm_rep, init_map=self.init_map, coupling_map=self.coupling_map)
         routed_circ, _ = router.run(layers=1, msmt=False)
         return circuit_to_dag(QuantumCircuit.from_qasm_str(routed_circ))

--- a/ucc/transpilers/ucc_defaults.py
+++ b/ucc/transpilers/ucc_defaults.py
@@ -3,7 +3,6 @@ import os
 from qiskit.utils.parallel import CPU_COUNT
 from qiskit.transpiler import PassManager
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
-from qiskit.utils.parallel import CPU_COUNT
 from qiskit import user_config
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes import (
@@ -78,14 +77,14 @@ class UCCDefault1:
             # self.pass_manager.append(ElidePermutations())
             # self.pass_manager.append(SpectralMapping(coupling_list))
             # self.pass_manager.append(SetLayout(pass_manager_config.initial_layout))
-            self.pass_manager.append(
-               SabreLayout(
-                  coupling_map,
-                  max_iterations=4,
-                  swap_trials=_get_trial_count(20),
-                  layout_trials=_get_trial_count(20),
-               )
-            )
+            # self.pass_manager.append(
+            #    SabreLayout(
+            #       coupling_map,
+            #       max_iterations=4,
+            #       swap_trials=_get_trial_count(20),
+            #       layout_trials=_get_trial_count(20),
+            #    )
+            # )
             # self.pass_manager.append(
             #     SabreSwap(
             #         coupling_map,
@@ -93,8 +92,7 @@ class UCCDefault1:
             #         trials=_get_trial_count(20),
             #     )
             # )
-            init_map = self.pass_manager.property_set["layout"]
-            self.pass_manager.append(Py2QAN_Routing(init_map=init_map,coupling_map=coupling_map))
+            self.pass_manager.append(Py2QAN_Routing(coupling_map=coupling_map))
             self.add_local_passes(1)
 
     def run(self, circuits, coupling_list=None):

--- a/ucc/transpilers/ucc_defaults.py
+++ b/ucc/transpilers/ucc_defaults.py
@@ -20,7 +20,7 @@ from qiskit.transpiler.passes import (
 )
 from qiskit.transpiler.passes.synthesis.unitary_synthesis import DefaultUnitarySynthesis
 # from ucc.transpiler_passes.sabre_swap import SabreSwap
-from ucc.transpiler_passes.py2qan_plugin import Py2QAN_Mapping_Routing
+from ucc.transpiler_passes.py2qan_plugin import Py2QAN_Routing
 
 from ..transpiler_passes import  CommutativeCancellation, Collect2qBlocks, UnitarySynthesis, Optimize1qGatesDecomposition, CXCancellation, SpectralMapping
 
@@ -78,14 +78,14 @@ class UCCDefault1:
             # self.pass_manager.append(ElidePermutations())
             # self.pass_manager.append(SpectralMapping(coupling_list))
             # self.pass_manager.append(SetLayout(pass_manager_config.initial_layout))
-            # self.pass_manager.append(
-            #    SabreLayout(
-            #       coupling_map,
-            #       max_iterations=4,
-            #       swap_trials=_get_trial_count(20),
-            #       layout_trials=_get_trial_count(20),
-            #    )
-            # )
+            self.pass_manager.append(
+               SabreLayout(
+                  coupling_map,
+                  max_iterations=4,
+                  swap_trials=_get_trial_count(20),
+                  layout_trials=_get_trial_count(20),
+               )
+            )
             # self.pass_manager.append(
             #     SabreSwap(
             #         coupling_map,
@@ -93,7 +93,8 @@ class UCCDefault1:
             #         trials=_get_trial_count(20),
             #     )
             # )
-            self.pass_manager.append(Py2QAN_Mapping_Routing(coupling_map=coupling_map))
+            init_map = self.pass_manager.property_set["layout"]
+            self.pass_manager.append(Py2QAN_Routing(init_map=init_map,coupling_map=coupling_map))
             self.add_local_passes(1)
 
     def run(self, circuits, coupling_list=None):

--- a/ucc/transpilers/ucc_defaults.py
+++ b/ucc/transpilers/ucc_defaults.py
@@ -1,16 +1,33 @@
 #Construct a custom compiler
+import os
+from qiskit.utils.parallel import CPU_COUNT
 from qiskit.transpiler import PassManager
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
+from qiskit.utils.parallel import CPU_COUNT
+from qiskit import user_config
 from qiskit.transpiler import CouplingMap
-from qiskit.transpiler.passes import BasisTranslator, ConsolidateBlocks, CollectCliffords, HighLevelSynthesis, HLSConfig
+from qiskit.transpiler.passes import (
+    BasisTranslator,
+    ConsolidateBlocks,
+    CollectCliffords,
+    HighLevelSynthesis,
+    HLSConfig,
+    SabreLayout,
+    SabreSwap,
+    BasicSwap,
+    LookaheadSwap,
+    StochasticSwap,
+)
 from qiskit.transpiler.passes.synthesis.unitary_synthesis import DefaultUnitarySynthesis
+# from ucc.transpiler_passes.sabre_swap import SabreSwap
+from ucc.transpiler_passes.py2qan_plugin import Py2QAN_Mapping_Routing
+
+from ..transpiler_passes import  CommutativeCancellation, Collect2qBlocks, UnitarySynthesis, Optimize1qGatesDecomposition, CXCancellation, SpectralMapping
+
+from qiskit.transpiler.passes import Optimize1qGatesSimpleCommutation, ElidePermutations
 
 
-from ..transpiler_passes import  CommutativeCancellation, Collect2qBlocks, UnitarySynthesis, Optimize1qGatesDecomposition, CXCancellation, SpectralMapping, SabreLayout
-
-from qiskit.transpiler.passes import Optimize1qGatesSimpleCommutation
-
-
+CONFIG = user_config.get_config()
 
 
 # from ucc_passes.entanglement_net_to_layout import Decompose2qNetworkWithMap
@@ -58,8 +75,25 @@ class UCCDefault1:
     def add_map_passes(self, coupling_list = None):
         if coupling_list is not None:              
             coupling_map = CouplingMap(couplinglist=coupling_list)
-            self.pass_manager.append(SpectralMapping(coupling_list))
-            self.pass_manager.append(SabreLayout(coupling_map=coupling_map))
+            # self.pass_manager.append(ElidePermutations())
+            # self.pass_manager.append(SpectralMapping(coupling_list))
+            # self.pass_manager.append(SetLayout(pass_manager_config.initial_layout))
+            # self.pass_manager.append(
+            #    SabreLayout(
+            #       coupling_map,
+            #       max_iterations=4,
+            #       swap_trials=_get_trial_count(20),
+            #       layout_trials=_get_trial_count(20),
+            #    )
+            # )
+            # self.pass_manager.append(
+            #     SabreSwap(
+            #         coupling_map,
+            #         heuristic="decay",
+            #         trials=_get_trial_count(20),
+            #     )
+            # )
+            self.pass_manager.append(Py2QAN_Mapping_Routing(coupling_map=coupling_map))
             self.add_local_passes(1)
 
     def run(self, circuits, coupling_list=None):
@@ -68,5 +102,8 @@ class UCCDefault1:
         return out_circuits
 
 
-
+def _get_trial_count(default_trials=5):
+    if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+        return max(CPU_COUNT, default_trials)
+    return default_trials
 


### PR DESCRIPTION
Fixes #85 Improve routing algorithm.

Introduced algorithm from py2qan to improve routing. 

Options for including the 2QAN algorithm:
1. Adapt key parts of py2qan into UCC, in a similar fashion as adapted Qiskit passes
2. Upgrade the py2qan library to work with Qiskit 1.0 (and thus UCC) and make it a dependency of UCC.
