### PR TITLE
Add explicit Sphinx config in `.readthedocs.yaml` file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,7 @@
 version: 2
+sphinx:
+  # Path to our Sphinx configuration file.
+  configuration: docs/conf.py
 
 build:
   os: "ubuntu-22.04"


### PR DESCRIPTION
Fixes #179 . 

Adds our Sphinx path explicitly to `.readthedocs.yaml` . 

Otherwise RTD will no longer build UCC docs. 😿 