### PR TITLE
Minor docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ UCC interfaces automatically with multiple quantum computing frameworks, includi
 
 ### Installation
 
-**Note**: UCC requires Python version >= 3.12.
+**Note**: UCC requires Python version ≥ 3.12.
 
 ```bash
 pip install ucc

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -16,7 +16,7 @@ To install ``ucc`` run:
    pip install -e . # Editable mode
 
 
-UCC requires Python version :math:`\ge` 3.12. 
+UCC requires Python version ≥ 3.12. 
 
 Basic usage
 ***********

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -30,7 +30,7 @@ For example, we can define a random circuit in Qiskit and optimize it using the 
 
    from qiskit.circuit.random import random_clifford_circuit
    import ucc
-   from ucc.benchmarks.utils import count_multi_qubit_gates_qiskit
+   from benchmarks.utils import count_multi_qubit_gates_qiskit
 
 
    gates = ["cx", "cz", "cy", "swap", "x", "y", "z", "s", "sdg", "h"]

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -30,7 +30,7 @@ For example, we can define a random circuit in Qiskit and optimize it using the 
 
    from qiskit.circuit.random import random_clifford_circuit
    import ucc
-   from benchmarks.utils import count_multi_qubit_gates_qiskit
+   from benchmarks.scripts.common import count_multi_qubit_gates_qiskit
 
 
    gates = ["cx", "cz", "cy", "swap", "x", "y", "z", "s", "sdg", "h"]


### PR DESCRIPTION
Originally opened to update readme with python version requirement and fix rendering of that requirement in the user guide.

Also fixes import in #204 - import from `benchmarking` not `ucc.benchmarking`