### PR TITLE
Wording change to force run benchmarks

### DIFF
--- a/benchmarks/run_ucc_benchmarks.ipynb
+++ b/benchmarks/run_ucc_benchmarks.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# UCC benchmarks\n",
-    "In this notebook, we benchmark the performance of Unitary Fund's UCC compiler against qiskit, PyTKET and Cirq across a range of benchmarks for circuits of (100 qubits) each unless otherwise marked: \n",
+    "In this notebook, we benchmark the performance of Unitary Foundation's UCC compiler against qiskit, PyTKET and Cirq across a range of benchmarks for circuits of (100 qubits) each unless otherwise marked: \n",
     "\n",
     "- Quantum Approximate Optimization Algorithm (QAOA)\n",
     "- Quantum volume  (QV) calculation\n",


### PR DESCRIPTION
Trying to reproduce error when UCC benchmarks didn't run as expected: https://github.com/unitaryfund/ucc/actions/runs/13125410128 (results)
https://github.com/unitaryfund/ucc/actions/runs/13125252118 (benchmark run and re-run)

This PR just changes "Unitary Fund: to "Unitary Foundation" in the explanatory text of `run_benchmarks.ipynb` .