### PR TITLE
Fix read-the-docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,4 @@ build:
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with doc


### PR DESCRIPTION
Fixes #218.

Was a 1 letter typo, as I had created the `doc` dependency group in the `pyproject.toml` as part of the shift to poetry, but had changed the RTD conf to install the non-existent `doc*s*` dependency group. 