### PR TITLE
Update documentation to expand on design goals:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.foundation)
 
 
-The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnostic, high performance compilation of quantum circuits. UCC's goal is to make quantum programming simpler, faster, and more scalable, all while building on and contributing to the open source quantum ecosystem.
+The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnostic, high performance compilation of quantum circuits. UCC's goal is to gather together the best of open source compilation to make quantum programming simpler, faster, and more scalable.
 
 By leveraging [qBraid](https://github.com/qBraid/qBraid), UCC interfaces automatically with multiple quantum computing frameworks, including [Qiskit](https://github.com/Qiskit/qiskit), [Cirq](https://github.com/quantumlib/Cirq), and [PyTKET](https://github.com/CQCL/tket) and supports programs in OpenQASM 2 and [OpenQASM 3](https://openqasm.com/). For a full list of the latest supported interfaces, just call `ucc.supported_circuit_formats`.
 
 
 **Want to know more?**
 - Check out our [documentation](https://ucc.readthedocs.io/en/latest/), which you can build locally after installation by running `make html` in `ucc/docs/source`.
-- Read the [launch announcement](TODO) to learn more on the current state of UCC, its capabilities and future direction.
+- Read the [launch announcement](https://unitary.foundation/posts/2025_ucc_launch_blog) to learn more on the current state of UCC, its capabilities and future direction.
 - For code, repo, or theory questions, especially those requiring more detailed responses, submit a [Discussion](https://github.com/unitaryfund/ucc/discussions).
 - For casual or time sensitive questions, chat with us on [Discord](http://discord.unitary.foundation).
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.foundation)
 
 
-The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnostic, high performance compilation of quantum circuits.
+The **Unitary Compiler Collection (UCC)** is a Python library for frontend-agnostic, high performance compilation of quantum circuits. UCC's goal is to make quantum programming simpler, faster, and more scalable, all while building on and contributing to the open source quantum ecosystem.
 
-UCC interfaces automatically with multiple quantum computing frameworks, including [Qiskit](https://github.com/Qiskit/qiskit), [Cirq](https://github.com/quantumlib/Cirq), and [PyTKET](https://github.com/CQCL/tket) and supports programs in OpenQASM 2 and [OpenQASM 3](https://openqasm.com/). For a full list of the latest supported interfaces, just call `ucc.supported_circuit_formats`.
+By leveraging [qBraid](https://github.com/qBraid/qBraid), UCC interfaces automatically with multiple quantum computing frameworks, including [Qiskit](https://github.com/Qiskit/qiskit), [Cirq](https://github.com/quantumlib/Cirq), and [PyTKET](https://github.com/CQCL/tket) and supports programs in OpenQASM 2 and [OpenQASM 3](https://openqasm.com/). For a full list of the latest supported interfaces, just call `ucc.supported_circuit_formats`.
 
 
 **Want to know more?**
 - Check out our [documentation](https://ucc.readthedocs.io/en/latest/), which you can build locally after installation by running `make html` in `ucc/docs/source`.
+- Read the [launch announcement](TODO) to learn more on the current state of UCC, its capabilities and future direction.
 - For code, repo, or theory questions, especially those requiring more detailed responses, submit a [Discussion](https://github.com/unitaryfund/ucc/discussions).
 - For casual or time sensitive questions, chat with us on [Discord](http://discord.unitary.foundation).
 
@@ -66,9 +67,10 @@ def test_cirq_compile():
     compile(circuit)
 ```
 <!-- start-how-does-ucc-stack-up -->
+<!-- comment used to strip this section from being added to the docs build-->
 ## How does UCC stack up?
 
-We run benchmarks regularly to compare against the most recent versions of the most popular quantum compiler frameworks for a range of circuits. Here's the latest:
+UCC seeks to provide an end-to-end compiler that works well for the majority of the users out of the box. Today, this is achieved by building on and customizing [Qiskit](https://github.com/Qiskit/qiskit) transpiler passes. To ensure these customizations improve performance and meet user needs, we regularly run benchmarks comparing UCC against the latest versions of leading quantum compiler frameworks across a range of circuits. Here’s the latest:
 ![alt text](benchmarks/latest_compiler_benchmarks_by_circuit.png)
 
 In addition to raw compilation stats, we simulate the compiled circuits with a noisy density matrix simulation to see how each compiler impacts performance.
@@ -80,13 +82,9 @@ And here you can see progress over time, with new package versions labeled for e
 ![alt text](benchmarks/avg_compiler_benchmarks_over_time.png)
 Note that the compile times before 2024-12-10 may have been run on different classical compute instances, so their runtime is not reported here, but you can find this data in benchmarks/results.
 After 2024-12-10, all data present in this plot is on the same compute instance using our [ucc-benchmarks](https://github.com/unitaryfund/ucc/blob/main/.github/workflows/ucc-benchmarks.yml) GitHub Actions workflow.
+
+To learn more about running these benchmarks, the overall benchmark philosophy, or how to contribute to improving the benchmarking methodology, check out the [benchmarking section](https://ucc.readthedocs.io/en/latest/benchmarking.html) in the docs.
 <!-- end-how-does-ucc-stack-up -->
-
-## Benchmarking
-
-You can benchmark the performance of ucc against other compilers using `./ucc/benchmarks/scripts/run_benchmarks.sh`. This script runs compiler benchmarks in parallel, so you will need to first install `parallel` to support it. If you setup `ucc` via `poetry` as recommended, either run the scripts after running `poetry shell` or prefix the script calls with `poetry run`.
-
-On Mac you can do this with `brew install parallel`.
 
 ## Contributing
 

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -1,0 +1,69 @@
+.. _benchmarks:
+
+Benchmarking
+############
+
+UCC includes a benchmarking suite to evaluate the performance of its quantum circuit compiler.
+These benchmarks help validate improvements, compare against other compilers, and guide future optimizations.
+This guide explains the **purpose**, **design**, and **execution** of UCC benchmarks and how you can contribute.
+
+Purpose
+-------
+UCC seeks to provide an end-to-end compiler that works well for the majority of the users out of the box across a
+wide range of use cases. To ensure our optimizations are effective, we run regular benchmarks that:
+
+- Compare UCC's compiler performance against leading quantum compilers.
+- Evaluate metrics such as gate count reduction, runtime performance and noise performance.
+- Test across a diverse set of quantum circuits, ensuring optimizations generalize beyond specific cases.
+- Provide reproducible results to guide future improvements in UCC’s compiler pipeline.
+
+Benchmark design & methodology
+------------------------------
+
+Our benchmarks follow a structured methodology to ensure consistency and reliability.
+
+1. **Circuits**: A selection of circuits for standard quantum algorithms such as QFT, QAOA, Quantum Volume, and QCNN. Circuits are selected to cover a range of qubit counts gate structures, and depth complexities.
+     - Many of the included circuits are from the `benchpress <https://github.com/Qiskit/benchpress>`_ benchmarking suite.
+
+2. **Compilers**: UCC is benchmarked comparing its default passes (defined in :class:`ucc.transpilers.ucc_defaults.UCCDefault1`) against other similar defaults for leading compilers, including `Qiskit <https://github.com/Qiskit/qiskit>`_, `Cirq <https://github.com/quantumlib/Cirq>`_, and `PyTKET <https://github.com/CQCL/tket>`_.
+      - The current compiler settings are defined `here <https://github.com/unitaryfund/ucc/blob/fde89f6e25f3adc2b47313e3e1c7cc0b5b2e1a18/benchmarks/scripts/common.py#L90-L207>`_ and we welcome contributions to these defaults as suggested below.
+
+3. **Metrics**: We track several metrics to evaluate compiler performance:
+    - *Compiled Gatecount Ratio*: Measures the ratio of 2-qubit gates in the compiled versus raw circuit.
+    - *Compilation Time*: Tracks the time taken to compile a circuit.
+    - *Observable under noise*: Measures the fidelity of the compiled circuit under noise models, using an observable relevant for that circuit.
+
+4. **Reproducibility**: In order to ensure the reliability of our benchmarks, we follow these practices:
+    - Benchmark scripts and results are available in the `UCC repository <https://github.com/unitaryfund/ucc/tree/main/benchmarks>`_.
+    - Results are stored in version-controlled reports to track improvements over time.
+    - Official results are run using a dedicated GH runner for consistent comparison.
+
+Running the benchmarks
+----------------------
+
+To run the benchmarks locally, first follow the steps in the
+:doc:`contributing guide <contributing>` to setup your dev environment. Then, run
+the benchmark script via:
+
+.. code-block:: sh
+
+   poetry run ./benchmarks/scripts/run_benchmarks.sh 8
+
+This will run the benchmarks in parallel on 8 processes, and store the results to
+``benchmarks/results/`` as CSV files.
+
+The script assumes you have GNU parallel available on your machine, available
+via ``apt-get install parallel`` on Ubuntu or ``brew install parallel`` on MacOS.
+
+Contributing to benchmarks
+--------------------------
+
+We welcome contributions to improve UCC’s benchmarking suite! This could include
+
+- **Adding New Benchmark Circuits** to cover an additional real-world use case.
+- **Improving Benchmark Metrics** to add additional metrics of interest to compare compiler performance.
+- **Optimizing Compiler Configuraitons** to improve the default configuration of compilers in the benchmark.
+     - The current compiler settings are defined `here <https://github.com/unitaryfund/ucc/blob/fde89f6e25f3adc2b47313e3e1c7cc0b5b2e1a18/benchmarks/scripts/common.py#L90-L207>`_.
+
+Take a look at
+:doc:`contributing guide <contributing>` for the more general steps to follow on making contributions to the UCC codebase.

--- a/docs/source/benchmarking.rst
+++ b/docs/source/benchmarking.rst
@@ -4,7 +4,7 @@ Benchmarking
 ############
 
 UCC includes a benchmarking suite to evaluate the performance of its quantum circuit compiler.
-These benchmarks help validate improvements, compare against other compilers, and guide future optimizations.
+These benchmarks help validate improvements, compare performance across compilers, and guide future optimizations.
 This guide explains the **purpose**, **design**, and **execution** of UCC benchmarks and how you can contribute.
 
 Purpose
@@ -31,12 +31,12 @@ Our benchmarks follow a structured methodology to ensure consistency and reliabi
 3. **Metrics**: We track several metrics to evaluate compiler performance:
     - *Compiled Gatecount Ratio*: Measures the ratio of 2-qubit gates in the compiled versus raw circuit.
     - *Compilation Time*: Tracks the time taken to compile a circuit.
-    - *Observable under noise*: Measures the fidelity of the compiled circuit under noise models, using an observable relevant for that circuit.
+    - *Observable under noise*: Measures the fidelity of the compiled circuit under noise, using an observable relevant for that circuit.
 
 4. **Reproducibility**: In order to ensure the reliability of our benchmarks, we follow these practices:
     - Benchmark scripts and results are available in the `UCC repository <https://github.com/unitaryfund/ucc/tree/main/benchmarks>`_.
     - Results are stored in version-controlled reports to track improvements over time.
-    - Official results are run using a dedicated GH runner for consistent comparison.
+    - Official results are run using a dedicated machine for consistent comparison.
 
 Running the benchmarks
 ----------------------
@@ -47,9 +47,9 @@ the benchmark script via:
 
 .. code-block:: sh
 
-   poetry run ./benchmarks/scripts/run_benchmarks.sh 8
+   poetry run ./benchmarks/scripts/run_benchmarks.sh <num_parallel>
 
-This will run the benchmarks in parallel on 8 processes, and store the results to
+where ``num_parallel`` is the number of parallel processes to run on. The results are stored in
 ``benchmarks/results/`` as CSV files.
 
 The script assumes you have GNU parallel available on your machine, available
@@ -62,8 +62,10 @@ We welcome contributions to improve UCC’s benchmarking suite! This could inclu
 
 - **Adding New Benchmark Circuits** to cover an additional real-world use case.
 - **Improving Benchmark Metrics** to add additional metrics of interest to compare compiler performance.
-- **Optimizing Compiler Configuraitons** to improve the default configuration of compilers in the benchmark.
+- **Optimizing Compiler Configurations** to improve the default configuration of compilers in the benchmark.
      - The current compiler settings are defined `here <https://github.com/unitaryfund/ucc/blob/fde89f6e25f3adc2b47313e3e1c7cc0b5b2e1a18/benchmarks/scripts/common.py#L90-L207>`_.
+     - For Qiskit, a change could be to the `optimization level set when transpiling <https://github.com/unitaryfund/ucc/blob/bbf6042951606a6999658036507e219674577f68/benchmarks/scripts/common.py#L108>`_.
+     - For Cirq, a change could update the `gate set optimization passes <https://github.com/unitaryfund/ucc/blob/bbf6042951606a6999658036507e219674577f68/benchmarks/scripts/common.py#L113>`_ used when compiling.
 
 Take a look at
 :doc:`contributing guide <contributing>` for the more general steps to follow on making contributions to the UCC codebase.

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -18,12 +18,12 @@ To release a new version of ``ucc`` on GitHub, follow the steps below.
     - Update the ``CHANGELOG.rst`` file with all new changes, improvements, and bug fixes since the previous release.
 
 3. **Commit Changes:**
-    - Commit the changes to `VERSION.txt` and `CHANGELOG.rst` and open a PR to get the changes reviewed.
+    - Commit the changes to ``pyproject.toml`` and `CHANGELOG.rst` and open a PR to get the changes reviewed.
 
 4. **Create a New Tag:**
     - Once the PR is merged, pull the changes to your local repository.
     - Create a new Git tag for the release. The tag name should match the version number (e.g., ``v1.1.0``).
-    
+
     .. code-block:: bash
 
         git tag v1.1.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Welcome to the docs!
    User Guide <user_guide.rst>
    API-doc <api.rst>
    Contributing Guide <contributing.rst>
+   Benchmarking <benchmarking.rst>
    Developer Documentation <dev.rst>
    Code of Conduct <CODE_OF_CONDUCT.rst>
 


### PR DESCRIPTION
Updates the README to add more context on UCC's goals and place in the ecosystem.

Adds a benchmarking section to the docs to give more details on the benchmark suite design and how users can contribute or suggest improvements.

Attempts to address both #242 and #202.