### PR TITLE
Improve reproducibility and consistency of benchmarking workflow

### DIFF
--- a/.github/workflows/ucc-benchmarks.yml
+++ b/.github/workflows/ucc-benchmarks.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: 'main'
 
+# Ensure only one instance of the workflow is running at a time
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   run-benchmarks:
     runs-on: ucc-benchmarks-8-core-U22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ POETRY_VIRTUALENVS_PATH=/venv
 # Install (rarely changing) dependencies only using Poetry to leverage docker caching
 RUN --mount=type=cache,target=/tmp/poetry_cache poetry install --no-root
 
-# Update to the latest version of the compiler libraries dependent libraries
-RUN --mount=type=cache,target=/tmp/poetry_cache poetry update
-
 # Install the `ucc` package itself
 RUN poetry install
 

--- a/benchmarks/scripts/expval_benchmark.py
+++ b/benchmarks/scripts/expval_benchmark.py
@@ -83,7 +83,9 @@ def simulate_density_matrix(circuit: qiskit.QuantumCircuit) -> np.ndarray:
         circuit, SINGLE_QUBIT_ERROR_RATE, TWO_QUBIT_ERROR_RATE
     )
     simulator = AerSimulator(
-        method="density_matrix", noise_model=depolarizing_noise
+        method="density_matrix",
+        noise_model=depolarizing_noise,
+        max_parallel_threads=1,
     )
     return simulator.run(circuit).result().data()["density_matrix"]
 
@@ -161,7 +163,7 @@ def fetch_pre_post_compiled_circuits(
 
 def get_heavy_bitstrings(circuit: qiskit.QuantumCircuit) -> Set[str]:
     """ "Determine the heavy bitstrings of the circuit."""
-    simulator = AerSimulator(method="statevector")
+    simulator = AerSimulator(method="statevector", max_parallel_threads=1)
     result = simulator.run(circuit, shots=1024).result()
     counts = list(result.get_counts().items())
     median = np.median([c for (_, c) in counts])
@@ -190,11 +192,10 @@ def estimate_heavy_output_prob(
             noise_model=create_depolarizing_noise_model(
                 circuit, SINGLE_QUBIT_ERROR_RATE, TWO_QUBIT_ERROR_RATE
             ),
+            max_parallel_threads=1,
         )
     else:
-        simulator = AerSimulator(
-            method="statevector",
-        )
+        simulator = AerSimulator(method="statevector", max_parallel_threads=1)
     result = simulator.run(circuit).result()
 
     heavy_counts = sum(


### PR DESCRIPTION
These changes will
1. Reduce the parallelism in the benchmarking runs to minimize contention that might otherwise impact the results. This includes restricting Qiskit-AER simulations to a maximum of 1 parallel thread and run expected value benchmarks separate in parallel separate from timing benchmarks in parallel. ~~and forcing just 1 parallel job in the benchmark script itself~~.

2. Use the locked version of dependencies in the benchmarking runs to avoid an uncontrolled change in a dependent library or transitive dependency.

3. Ensure only one instance of the benchmark github workflow runs at a time by specifying a concurrency group.

This partially addresses #251 