### PR TITLE
Change plot resolution to per release in plot over time scripts

### DIFF
--- a/benchmarks/scripts/common.py
+++ b/benchmarks/scripts/common.py
@@ -3,6 +3,7 @@ import platform
 import os
 import pandas as pd
 import matplotlib
+import re
 from datetime import datetime
 from typing import List
 from cirq import optimize_for_target_gateset
@@ -525,3 +526,8 @@ def adjust_axes_to_fit_labels(
     # Set the new axis limits
     ax.set_xlim(x_min, x_max)
     ax.set_ylim(y_min, y_max)
+
+
+def extract_compiler_versions(header):
+    pattern = r"(\w+)=([\d\.]+)"
+    return dict(re.findall(pattern, header))

--- a/benchmarks/scripts/plot_avg_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_avg_benchmarks_over_time.py
@@ -179,7 +179,9 @@ for compiler in unique_compilers:
 
 # Add annotations for version changes
 for date in filtered_avg_compile_time["date"].unique():
-    date_data = filtered_avg_compile_time[filtered_avg_compile_time["date"] == date]
+    date_data = filtered_avg_compile_time[
+        filtered_avg_compile_time["date"] == date
+    ]
     # Sort date_data in order of compiled_ratio
     date_data = date_data.sort_values("compile_time")
     for _, row in date_data.iterrows():

--- a/benchmarks/scripts/plot_avg_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_avg_benchmarks_over_time.py
@@ -110,48 +110,43 @@ for compiler in unique_compilers:
         color=color_map[compiler],
     )
 
+# Keep track of last compiler version seen over time to track version changes
+last_version_seen = {compiler: None for compiler in unique_compilers}
 
 previous_bboxes = []
+# Now iterate over each compiler entry and annotate if it's a new version, if so label it
+for date in avg_compiled_ratio["date"].unique():
+    date_data = avg_compiled_ratio[avg_compiled_ratio["date"] == date]
+    # Sort date_data in order of compiled_ratio
+    date_data = date_data.sort_values("compiled_ratio")
+    # Now iterate over each compiler entry and annotate if it's a new version
+    for _, row in date_data.iterrows():
+        # Get the version for this date
+        current_version = row["compiler_version"]
+        compiler = row["compiler"]
+        compiled_ratio = row["compiled_ratio"]
 
-# Find the latest version for each package
-latest_versions = avg_compiled_ratio.groupby("compiler")[
-    "compiler_version"
-].max()
-# Filter to keep only rows with the latest version
-avg_compiled_ratio_latest_versions = avg_compiled_ratio[
-    avg_compiled_ratio["compiler_version"].isin(latest_versions)
-]
-#  Find the first appearance date of each latest version
-first_appearance_dates = (
-    avg_compiled_ratio_latest_versions.groupby(
-        ["compiler", "compiler_version", "compiled_ratio"]
-    )["date"]
-    .min()
-    .reset_index()
-)
-
-
-for _, row in first_appearance_dates.iterrows():
-    # Get the version for this date
-    current_version = row["compiler_version"]
-    compiler = row["compiler"]
-    compiled_ratio = row["compiled_ratio"]
-
-    text = f"{compiler}={current_version}"
-    xy = (row["date"], compiled_ratio)
-    color = color_map[compiler]
-    # Add the annotation and adjust for overlap
-    annotate_and_adjust(
-        ax=ax[0],
-        text=text,
-        xy=xy,
-        color=color,
-        previous_bboxes=previous_bboxes,
-        offset=(0, 20),  # Initial offset
-        increment=2,  # Vertical adjustment step
-        max_attempts=15,
-    )
-    # plt.pause(0.1)
+        # Check if the version has changed
+        if current_version != last_version_seen[compiler]:
+            text = f"{current_version}"
+            xy = (row["date"], compiled_ratio)
+            color = color_map[compiler]
+            renderer = fig.canvas.get_renderer()
+            previous_bboxes.append(ax[0].get_tightbbox(renderer))
+            # Add the annotation and adjust for overlap
+            annotate_and_adjust(
+                ax=ax[0],
+                text=text,
+                xy=xy,
+                color=color,
+                previous_bboxes=previous_bboxes,
+                offset=(0, 20),  # Initial offset
+                increment=2,  # Vertical adjustment step
+                max_attempts=15,
+            )
+            # plt.pause(0.1)
+            # Update the last seen version for this compiler
+            last_version_seen[compiler] = current_version
 
 # Set y axis range to be slightly larger than data range
 adjust_axes_to_fit_labels(ax[0], y_scale=[1.1, 1.3])
@@ -181,45 +176,37 @@ for compiler in unique_compilers:
     )
 
 # Add annotations for version changes
-latest_versions = avg_compile_time.groupby("compiler")[
-    "compiler_version"
-].max()
-avg_compile_time_latest_versions = avg_compile_time[
-    avg_compile_time["compiler_version"].isin(latest_versions)
-]
-first_appearance_dates = (
-    avg_compile_time_latest_versions.groupby(
-        ["compiler", "compiler_version", "compile_time"]
-    )["date"]
-    .min()
-    .reset_index()
-)
-for _, row in first_appearance_dates.iterrows():
-    # Get the version for this date
-    current_version = row["compiler_version"]
-    compiler = row["compiler"]
-    compile_time = row["compile_time"]
+for date in avg_compile_time["date"].unique():
+    date_data = avg_compile_time[avg_compile_time["date"] == date]
+    # Sort date_data in order of compiled_ratio
+    date_data = date_data.sort_values("compile_time")
+    for _, row in date_data.iterrows():
+        # print(row, '\n')
+        # Get the version for this date
+        current_version = row["compiler_version"]
+        compiler = row["compiler"]
+        compile_time = row["compile_time"]
 
-    # Check if the version has changed
-    if current_version != last_version_seen[compiler]:
-        text = f"{compiler}={current_version}"
-        xy = (row["date"], compile_time)
-        color = color_map[compiler]
+        # Check if the version has changed
+        if current_version != last_version_seen[compiler]:
+            text = f"{current_version}"
+            xy = (row["date"], compile_time)
+            color = color_map[compiler]
 
-        # Add the annotation and adjust for overlap
-        annotate_and_adjust(
-            ax=ax[1],
-            text=text,
-            xy=xy,
-            color=color,
-            previous_bboxes=previous_bboxes,
-            offset=(0, 20),  # Initial offset
-            increment=2,  # Vertical adjustment step
-            max_attempts=15,
-        )
-        # plt.pause(0.1)
-        # Update the last seen version for this compiler
-        last_version_seen[compiler] = current_version
+            # Add the annotation and adjust for overlap
+            annotate_and_adjust(
+                ax=ax[1],
+                text=text,
+                xy=xy,
+                color=color,
+                previous_bboxes=previous_bboxes,
+                offset=(0, 20),  # Initial offset
+                increment=2,  # Vertical adjustment step
+                max_attempts=15,
+            )
+            # plt.pause(0.1)
+            # Update the last seen version for this compiler
+            last_version_seen[compiler] = current_version
 
 ax[1].set_title("Average Compile Time over Time")
 ax[1].set_ylabel("Compile Time (s)")

--- a/benchmarks/scripts/plot_avg_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_avg_benchmarks_over_time.py
@@ -179,7 +179,7 @@ for compiler in unique_compilers:
 
 # Add annotations for version changes
 for date in filtered_avg_compile_time["date"].unique():
-    date_data = filtered_avg_compile_time[avg_compile_time["date"] == date]
+    date_data = filtered_avg_compile_time[filtered_avg_compile_time["date"] == date]
     # Sort date_data in order of compiled_ratio
     date_data = date_data.sort_values("compile_time")
     for _, row in date_data.iterrows():

--- a/benchmarks/scripts/plot_avg_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_avg_benchmarks_over_time.py
@@ -72,6 +72,14 @@ avg_compiled_ratio = (
     .reset_index()
     .sort_values("date")
 )
+# Sort the dataframe by package, date, and version
+avg_compiled_ratio = avg_compiled_ratio.sort_values(
+    by=["date", "compiler", "compiler_version"], ascending=[True, True, True]
+)
+# Keep only the highest version per (date, package)
+avg_compiled_ratio = avg_compiled_ratio.drop_duplicates(
+    subset=["date", "compiler"], keep="last"
+)
 
 # Find the average compile time for each compiler on each date
 avg_compile_time = (
@@ -80,7 +88,14 @@ avg_compile_time = (
     .reset_index()
     .sort_values("date")
 )
-
+# Sort the dataframe by package, date, and version
+avg_compile_time = avg_compile_time.sort_values(
+    by=["date", "compiler", "compiler_version"], ascending=[True, True, True]
+)
+# Keep only the highest version per (date, package)
+avg_compile_time = avg_compile_time.drop_duplicates(
+    subset=["date", "compiler"], keep="last"
+)
 
 ###### Plotting
 # Ensure colors are consistently assigned to each compiler
@@ -131,8 +146,6 @@ for date in avg_compiled_ratio["date"].unique():
             text = f"{current_version}"
             xy = (row["date"], compiled_ratio)
             color = color_map[compiler]
-            renderer = fig.canvas.get_renderer()
-            previous_bboxes.append(ax[0].get_tightbbox(renderer))
             # Add the annotation and adjust for overlap
             annotate_and_adjust(
                 ax=ax[0],

--- a/benchmarks/scripts/plot_avg_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_avg_benchmarks_over_time.py
@@ -110,43 +110,48 @@ for compiler in unique_compilers:
         color=color_map[compiler],
     )
 
-# Keep track of last compiler version seen over time to track version changes
-last_version_seen = {compiler: None for compiler in unique_compilers}
 
 previous_bboxes = []
-# Now iterate over each compiler entry and annotate if it's a new version, if so label it
-for date in avg_compiled_ratio["date"].unique():
-    date_data = avg_compiled_ratio[avg_compiled_ratio["date"] == date]
-    # Sort date_data in order of compiled_ratio
-    date_data = date_data.sort_values("compiled_ratio")
-    # Now iterate over each compiler entry and annotate if it's a new version
-    for _, row in date_data.iterrows():
-        # Get the version for this date
-        current_version = row["compiler_version"]
-        compiler = row["compiler"]
-        compiled_ratio = row["compiled_ratio"]
 
-        # Check if the version has changed
-        if current_version != last_version_seen[compiler]:
-            text = f"{compiler}={current_version}"
-            xy = (row["date"], compiled_ratio)
-            color = color_map[compiler]
-            renderer = fig.canvas.get_renderer()
-            previous_bboxes.append(ax[0].get_tightbbox(renderer))
-            # Add the annotation and adjust for overlap
-            annotate_and_adjust(
-                ax=ax[0],
-                text=text,
-                xy=xy,
-                color=color,
-                previous_bboxes=previous_bboxes,
-                offset=(0, 20),  # Initial offset
-                increment=2,  # Vertical adjustment step
-                max_attempts=15,
-            )
-            # plt.pause(0.1)
-            # Update the last seen version for this compiler
-            last_version_seen[compiler] = current_version
+# Find the latest version for each package
+latest_versions = avg_compiled_ratio.groupby("compiler")[
+    "compiler_version"
+].max()
+# Filter to keep only rows with the latest version
+avg_compiled_ratio_latest_versions = avg_compiled_ratio[
+    avg_compiled_ratio["compiler_version"].isin(latest_versions)
+]
+#  Find the first appearance date of each latest version
+first_appearance_dates = (
+    avg_compiled_ratio_latest_versions.groupby(
+        ["compiler", "compiler_version", "compiled_ratio"]
+    )["date"]
+    .min()
+    .reset_index()
+)
+
+
+for _, row in first_appearance_dates.iterrows():
+    # Get the version for this date
+    current_version = row["compiler_version"]
+    compiler = row["compiler"]
+    compiled_ratio = row["compiled_ratio"]
+
+    text = f"{compiler}={current_version}"
+    xy = (row["date"], compiled_ratio)
+    color = color_map[compiler]
+    # Add the annotation and adjust for overlap
+    annotate_and_adjust(
+        ax=ax[0],
+        text=text,
+        xy=xy,
+        color=color,
+        previous_bboxes=previous_bboxes,
+        offset=(0, 20),  # Initial offset
+        increment=2,  # Vertical adjustment step
+        max_attempts=15,
+    )
+    # plt.pause(0.1)
 
 # Set y axis range to be slightly larger than data range
 adjust_axes_to_fit_labels(ax[0], y_scale=[1.1, 1.3])
@@ -176,37 +181,45 @@ for compiler in unique_compilers:
     )
 
 # Add annotations for version changes
-for date in avg_compile_time["date"].unique():
-    date_data = avg_compile_time[avg_compile_time["date"] == date]
-    # Sort date_data in order of compiled_ratio
-    date_data = date_data.sort_values("compile_time")
-    for _, row in date_data.iterrows():
-        # print(row, '\n')
-        # Get the version for this date
-        current_version = row["compiler_version"]
-        compiler = row["compiler"]
-        compile_time = row["compile_time"]
+latest_versions = avg_compile_time.groupby("compiler")[
+    "compiler_version"
+].max()
+avg_compile_time_latest_versions = avg_compile_time[
+    avg_compile_time["compiler_version"].isin(latest_versions)
+]
+first_appearance_dates = (
+    avg_compile_time_latest_versions.groupby(
+        ["compiler", "compiler_version", "compile_time"]
+    )["date"]
+    .min()
+    .reset_index()
+)
+for _, row in first_appearance_dates.iterrows():
+    # Get the version for this date
+    current_version = row["compiler_version"]
+    compiler = row["compiler"]
+    compile_time = row["compile_time"]
 
-        # Check if the version has changed
-        if current_version != last_version_seen[compiler]:
-            text = f"{compiler}={current_version}"
-            xy = (row["date"], compile_time)
-            color = color_map[compiler]
+    # Check if the version has changed
+    if current_version != last_version_seen[compiler]:
+        text = f"{compiler}={current_version}"
+        xy = (row["date"], compile_time)
+        color = color_map[compiler]
 
-            # Add the annotation and adjust for overlap
-            annotate_and_adjust(
-                ax=ax[1],
-                text=text,
-                xy=xy,
-                color=color,
-                previous_bboxes=previous_bboxes,
-                offset=(0, 20),  # Initial offset
-                increment=2,  # Vertical adjustment step
-                max_attempts=15,
-            )
-            # plt.pause(0.1)
-            # Update the last seen version for this compiler
-            last_version_seen[compiler] = current_version
+        # Add the annotation and adjust for overlap
+        annotate_and_adjust(
+            ax=ax[1],
+            text=text,
+            xy=xy,
+            color=color,
+            previous_bboxes=previous_bboxes,
+            offset=(0, 20),  # Initial offset
+            increment=2,  # Vertical adjustment step
+            max_attempts=15,
+        )
+        # plt.pause(0.1)
+        # Update the last seen version for this compiler
+        last_version_seen[compiler] = current_version
 
 ax[1].set_title("Average Compile Time over Time")
 ax[1].set_ylabel("Compile Time (s)")

--- a/benchmarks/scripts/plot_expval_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_expval_benchmarks_over_time.py
@@ -39,18 +39,20 @@ df_all = pd.concat(dfs, ignore_index=True)
 # Convert the 'date' column to datetime
 df_all["date"] = pd.to_datetime(df_all["date"])
 
-unique_versions = sorted(df_all["compiler_version"].unique())
-dates = []
-for version in unique_versions:
-    df_versions = df_all[df_all["compiler_version"] == version]
-    earliest_date = sorted(df_versions["date"].unique())[0]
-    dates.append(earliest_date)
+# Get the earliest date for each compiler version
+new_version_dates = df_all.groupby(["compiler", "compiler_version"])[
+    "date"
+].min()
 
-df_filtered = df_all[df_all["date"].isin(dates)]
+# Get all unique first occurrence dates
+unique_dates = new_version_dates.unique()
+
+# Filter on first occurrence of each compiler version based on the date
+df_all = df_all[df_all["date"].isin(unique_dates)]
 
 # Step 6: Group by date and compiler, and calculate the average absolute error
 summary = (
-    df_filtered.groupby(["date", "compiler"])
+    df_all.groupby(["date", "compiler"])
     .agg(avg_absolute_error=("absolute_error", "mean"))
     .reset_index()
 )

--- a/benchmarks/scripts/plot_expval_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_expval_benchmarks_over_time.py
@@ -83,20 +83,6 @@ for compiler in unique_compilers:
 # Customize plot
 last_version_seen = {compiler: None for compiler in unique_compilers}
 
-# Find the latest version for each package
-latest_versions = summary.groupby("compiler")["compiler_version"].max()
-# Filter to keep only rows with the latest version
-avg_absolute_error_latest_versions = summary[
-    summary["compiler_version"].isin(latest_versions)
-]
-#  Find the first appearance date of each latest version
-first_appearance_dates = (
-    avg_absolute_error_latest_versions.groupby(
-        ["compiler", "compiler_version", "avg_absolute_error"]
-    )["date"]
-    .min()
-    .reset_index()
-)
 
 previous_bboxes = []
 

--- a/benchmarks/scripts/plot_expval_benchmarks_over_time.py
+++ b/benchmarks/scripts/plot_expval_benchmarks_over_time.py
@@ -100,15 +100,15 @@ first_appearance_dates = (
 
 previous_bboxes = []
 
-for _, row in first_appearance_dates.iterrows():
+for _, row in summary.iterrows():
     # Get the version for this date
     current_version = row["compiler_version"]
     compiler = row["compiler"]
     avg_absolute_error = row["avg_absolute_error"]
 
     if current_version != last_version_seen[compiler]:
-        text = f"{compiler}={current_version}"
-        xy = xy = (row["date"], avg_absolute_error)
+        text = f"{current_version}"
+        xy = (row["date"], avg_absolute_error)
         color = color_map[compiler]
 
         # Add the annotation and adjust for overlap


### PR DESCRIPTION
Fixes #200.

Change plot resolution to per compiler release in plot over time scripts, so the plots will look like the following:
![image](https://github.com/user-attachments/assets/9a29a5db-eedd-48c2-b95f-00b445020fa7)
![image](https://github.com/user-attachments/assets/6203dd07-2b5c-4bf2-9e0e-510e9d8e8382)

Note: I pasted (instead of pushed) these plots because they'd have to be removed before merge anyway.