### PR TITLE
Run pytest before ruff linter checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
 
       - name: Install dependencies & ucc
         run: poetry install
-
+        
+      - name: Run tests
+        run: poetry run pytest ucc --verbose
+        
       - name: Run linter
         run: poetry run ruff check
 
       - name: Run formatter check
         run: poetry run ruff format --check
-
-      - name: Run tests
-        run: poetry run pytest ucc --verbose


### PR DESCRIPTION
I want to test the functionality of a change before checking the formatting. In this way you get a failure like on an unused import before the code itself runs: https://github.com/unitaryfund/ucc/actions/runs/13554895918/job/37886926715