### PR TITLE
Support custom passes in compile

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -89,12 +89,12 @@ UCC settings can be adjusted using the keyword arguments of the ``ucc.compile()`
    ucc.compile(
        circuit,
        return_format="original",
-       target_device=None,
+       compiler=None,
    )
 
 
 - ``return_format`` is the format in which the input circuit will be returned, e.g. "TKET" or "OpenQASM2". Check ``ucc.supported_circuit_formats()`` for supported circuit formats. Default is the format of input circuit.
-- ``target_device`` can be specified as a Qiskit backend or coupling map, or a list of connections between qubits. If None, all-to-all connectivity is assumed. If a Qiskit backend or coupling map is specified, only the coupling list extracted from the backend is used.
+- ``compiler`` is an instance of a custom compiler object to manage compiler passes. Default is ``UCCDefault1``.
 
 Writing a custom pass
 =====================
@@ -139,7 +139,7 @@ In the following example we show how to add passes for merging single qubit rota
 
    from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
    from qiskit.transpiler.passes import BasisTranslator, Optimize1qGatesSimpleCommutation
-   from ucc import UCCDefault1
+   from ucc import UCCDefault1, compile
 
 
    single_q_basis = ['rz', 'rx', 'ry', 'h']
@@ -149,19 +149,19 @@ In the following example we show how to add passes for merging single qubit rota
    ucc_compiler.pass_manager.append(Optimize1qGatesSimpleCommutation(basis=single_q_basis))
    ucc_compiler.pass_manager.append(BasisTranslator(sel, target_basis=target_basis))
 
-   custom_compiled_circuit = ucc_compiler.run(circuit_to_compile)
+   custom_compiled_circuit = compile(circuit_to_compile, compiler = ucc_compiler)
 
 
 Alternatively, we can add a custom pass in the sequence, as shown in the following example.
 
 .. testcode:: custom_pass
 
-   from ucc import UCCDefault1
+   from ucc import UCCDefault1, compile
    ucc_compiler = UCCDefault1()
 
    ucc_compiler.pass_manager.append(MyCustomPass())
 
-   custom_compiled_circuit = ucc_compiler.run(circuit_to_compile)
+   custom_compiled_circuit = compile(circuit_to_compile, compiler = ucc_compiler)
 
 
 A note on terminology

--- a/ucc/compile.py
+++ b/ucc/compile.py
@@ -28,7 +28,7 @@ supported_circuit_formats = ConversionGraph().nodes()
 def compile(
     circuit,
     return_format="original",
-    target_device=None,
+    compiler=None,
 ):
     """Compiles the provided quantum `circuit` by translating it to a Qiskit
     circuit, transpiling it, and returning the optimized circuit in the
@@ -39,7 +39,7 @@ def compile(
         return_format (str): The format in which your circuit will be returned.
             e.g., "TKET", "OpenQASM2". Check ``ucc.supported_circuit_formats()``.
             Defaults to the format of the input circuit.
-        target_device (qiskit.transpiler.Target): (optional) The target device to compile the circuit for. None if no device to target
+        compiler (object): The compiler to be used. If None, the default UCCDefault1 is used
 
     Returns:
         object: The compiled circuit in the specified format.
@@ -47,9 +47,11 @@ def compile(
     if return_format == "original":
         return_format = get_program_type_alias(circuit)
 
+    compiler = UCCDefault1() if compiler is None else compiler
+
     # Translate to Qiskit Circuit object
     qiskit_circuit = transpile(circuit, "qiskit")
-    compiled_circuit = UCCDefault1(target_device=target_device).run(
+    compiled_circuit = compiler.run(
         qiskit_circuit,
     )
 


### PR DESCRIPTION
Updates the top-level ucc compile function to take an optional compiler parameter. This compiler is the class that contains the pass_manager which compiles the circuit. If unspecified, defaults to UCCDefault1.

Resolves #292 