### PR TITLE
Create first draft of python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,58 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "1.8.2" # Adjust to your required Poetry version
+
+      - name: Configure Poetry to use virtualenv inside project
+        run: poetry config virtualenvs.in-project true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Build release distributions
+        run: poetry build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write  # Enables Trusted Publishing (no need for API token)
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ucc/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Publish Python Package
 
 on:
   release:
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # Required for OpenID Connect authentication with PyPI
 
 jobs:
   release-build:
@@ -14,16 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: "1.8.2" # Adjust to your required Poetry version
-
-      - name: Configure Poetry to use virtualenv inside project
-        run: poetry config virtualenvs.in-project true
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-root
+      - uses: abatilo/actions-poetry@v2
 
       - name: Build release distributions
         run: poetry build
@@ -34,13 +26,34 @@ jobs:
           name: release-dists
           path: dist/
 
+  testpypi-publish:
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/ucc/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+
   pypi-publish:
     runs-on: ubuntu-latest
-    needs:
-      - release-build
+    needs: testpypi-publish
+    if: github.ref == 'refs/heads/main'  # Ensures only main branch triggers PyPI deploy
     permissions:
-      id-token: write  # Enables Trusted Publishing (no need for API token)
-
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/ucc/${{ github.event.release.name }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,7 @@ name: Publish Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:  # This allows manual triggering of the workflow
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # Required for OpenID Connect authentication with PyPI
 
 jobs:
   release-build:
@@ -17,6 +16,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: abatilo/actions-poetry@v2
+
+      - name: Install dependencies
+        run: poetry install --no-root
 
       - name: Build release distributions
         run: poetry build
@@ -34,7 +36,7 @@ jobs:
       id-token: write
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/ucc/${{ github.event.release.name }}
+      url: https://test.pypi.org/project/ucc/${{ github.event.release.tag_name }}
 
     steps:
       - name: Retrieve release distributions
@@ -49,15 +51,18 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/
 
+      - name: Clean up distributions
+        run: rm -rf dist/
+
   pypi-publish:
     runs-on: ubuntu-latest
     needs: testpypi-publish
-    if: github.ref == 'refs/heads/main'  # Ensures only main branch triggers PyPI deploy
+    if: github.event.release.target_commitish == 'main'  # Ensures release is from main branch
     permissions:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/project/ucc/${{ github.event.release.name }}
+      url: https://pypi.org/project/ucc/${{ github.event.release.tag_name }}
 
     steps:
       - name: Retrieve release distributions
@@ -70,3 +75,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+
+      - name: Clean up distributions
+        run: rm -rf dist/


### PR DESCRIPTION
Add an automated workflow file for publishing to PyPI, which should run automatically upon a release. 
It includes a test upload to TestPyPI and then requires manual approval from @jordandsullivan , @Misty-W , or @bachase to publish to real PyPI. 

Need to merge into main to be able to test the manual dispatch function. 