### PR TITLE
Add manual trigger to PyPI publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,17 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  debug:
-      runs-on: ubuntu-latest
-      if: (github.event.release.target_commitish == 'main' && github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/jordandsullivan-patch-1')      
-      steps:
-        - name: Debug event data
-          run: |
-            echo "Event name: ${{ github.event_name }}"
-            echo "Release target_commitish: ${{ github.event.release.target_commitish }}"
-            echo "Ref: ${{ github.ref }}"
-
-
   release-build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,8 +11,7 @@ permissions:
 jobs:
   debug:
       runs-on: ubuntu-latest
-      if: github.event.release.target_commitish == 'refs/heads/jordandsullivan-patch-1'  # Ensures release is from main branch
-      steps:
+      if: (github.event.release.target_commitish == 'main' && github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/jordandsullivan-patch-1')      steps:
         - name: Debug event data
           run: |
             echo "Event name: ${{ github.event_name }}"
@@ -70,8 +69,8 @@ jobs:
   
   pypi-publish:
     runs-on: ubuntu-latest
-    needs: testpypi-publish
-    if: github.event.release.target_commitish == 'refs/heads/main'  # Ensures release is from main branch
+    needs: testpypi-publish # If statement guarantees we are on main and either in a release or manual dispatch event. 
+    if: (github.event.release.target_commitish == 'main' && github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     permissions:
       id-token: write
     environment:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   debug:
       runs-on: ubuntu-latest
-      if: github.event.release.target_commitish == 'refs/heads/main'  # Ensures release is from main branch
+      if: github.event.release.target_commitish == 'refs/heads/jordandsullivan-patch-1'  # Ensures release is from main branch
       steps:
         - name: Debug event data
           run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -69,7 +69,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs: testpypi-publish
-    if: github.event.release.target_commitish == 'main'  # Ensures release is from main branch
+    if: github.event.release.target_commitish == 'refs/heads/main'  # Ensures release is from main branch
     permissions:
       id-token: write
     environment:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,8 @@ permissions:
 jobs:
   debug:
       runs-on: ubuntu-latest
-      if: (github.event.release.target_commitish == 'main' && github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/jordandsullivan-patch-1')      steps:
+      if: (github.event.release.target_commitish == 'main' && github.event_name == 'release') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/jordandsullivan-patch-1')      
+      steps:
         - name: Debug event data
           run: |
             echo "Event name: ${{ github.event_name }}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,12 +11,14 @@ permissions:
 jobs:
   debug:
       runs-on: ubuntu-latest
+      if: github.event.release.target_commitish == 'refs/heads/main'  # Ensures release is from main branch
       steps:
         - name: Debug event data
           run: |
             echo "Event name: ${{ github.event_name }}"
             echo "Release target_commitish: ${{ github.event.release.target_commitish }}"
             echo "Ref: ${{ github.ref }}"
+
 
   release-build:
     runs-on: ubuntu-latest
@@ -65,7 +67,7 @@ jobs:
 
       - name: Clean up distributions
         run: rm -rf dist/
-
+  
   pypi-publish:
     runs-on: ubuntu-latest
     needs: testpypi-publish

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,15 @@ permissions:
   contents: read
 
 jobs:
+  debug:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Debug event data
+          run: |
+            echo "Event name: ${{ github.event_name }}"
+            echo "Release target_commitish: ${{ github.event.release.target_commitish }}"
+            echo "Ref: ${{ github.ref }}"
+
   release-build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This will allow us to manually trigger a deployment to PyPI, in addition to automatically triggering upon a release. The relevant code change is [here](https://github.com/unitaryfund/ucc/pull/311/files#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377R63). 